### PR TITLE
feat: add support for specifying boot args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@createdreamtech/carti-core": "^1.4.0",
+        "@createdreamtech/carti-core": "^1.5.0",
         "@ipld/dag-cbor": "^2.0.2",
         "@octokit/rest": "^18.0.12",
         "@types/commander": "^2.12.2",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@createdreamtech/carti-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.4.0.tgz",
-      "integrity": "sha512-NOn7kE3aF8yn6yTf4fGZ40TJxIj8u4hGDlZfJlN7bGBpmgHOKl3walw9oX1nb/vBMIPZKzdn1pyHSflMXIbN0A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.5.0.tgz",
+      "integrity": "sha512-2vAn1pABYWo9OT3t+d6M08q8pdCA86nD34rWI1kzBg5ppcKNXfoKQiTF0w015fpYO1FZRYOjlS7JriPorN8kEw==",
       "dependencies": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",
@@ -15078,9 +15078,9 @@
       }
     },
     "@createdreamtech/carti-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.4.0.tgz",
-      "integrity": "sha512-NOn7kE3aF8yn6yTf4fGZ40TJxIj8u4hGDlZfJlN7bGBpmgHOKl3walw9oX1nb/vBMIPZKzdn1pyHSflMXIbN0A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.5.0.tgz",
+      "integrity": "sha512-2vAn1pABYWo9OT3t+d6M08q8pdCA86nD34rWI1kzBg5ppcKNXfoKQiTF0w015fpYO1FZRYOjlS7JriPorN8kEw==",
       "requires": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@createdreamtech/carti-core": "^1.4.0",
+    "@createdreamtech/carti-core": "^1.5.0",
     "@ipld/dag-cbor": "^2.0.2",
     "@octokit/rest": "^18.0.12",
     "@types/commander": "^2.12.2",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -6,7 +6,7 @@ import { Repo } from "../repo"
 import { fetcher } from "../fetcher";
 import { BundleManager } from "../bundle"
 import fs from "fs-extra";
-import { CartiPackage, Ram, Rom, FlashDrive } from "@createdreamtech/carti-core/build/src/generated/machine_config_pkg_schema"
+import { CartiPackage, Ram, Rom, Boot, FlashDrive } from "@createdreamtech/carti-core/build/src/generated/machine_config_pkg_schema"
 
 export interface Config {
     localConfigStorage: CartiConfigStorage
@@ -37,8 +37,10 @@ export const config: Config = {
 }
 const defaultRom: Rom = {
     cid: "default-rom",
-    bootargs: "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet mtdparts=flash.0:-(root)",
     resolvedPath: "/opt/cartesi/share/images/rom.bin"
+}
+const defaultBoot: Boot = {
+    args: "ls",
 }
 const defaultRam: Ram = {
     cid: "default-ram",
@@ -56,7 +58,7 @@ const defaultFlash: FlashDrive = [
     }
 ]
 export async function initMachineConfig(): Promise<void> {
-    const packageCfg = { assets: [], machineConfig: { flash_drive: defaultFlash, ram: defaultRam, rom: defaultRom }, version: "0.0.0-development", }
+    const packageCfg = { assets: [], machineConfig: { flash_drive: defaultFlash, ram: defaultRam, rom: defaultRom, boot: defaultBoot }, version: "0.0.0-development", }
     const exists = await fs.pathExists(cartesiMachinePath)
     if (exists) {
         console.warn("Machine has already been init")
@@ -71,7 +73,7 @@ export async function getMachineConfig(): Promise<CartiPackage> {
         const configFile = await fs.readFile(cartesiMachinePath)
         return JSON.parse(configFile.toString())
     } catch (e) {
-        return { assets: [], machineConfig: { flash_drive: defaultFlash, ram: defaultRam, rom: defaultRom }, version: "", }
+        return { assets: [], machineConfig: { flash_drive: defaultFlash, ram: defaultRam, rom: defaultRom, boot: defaultBoot }, version: "", }
     }
 }
 


### PR DESCRIPTION
The boot command now allows you to set arguments and builds
default prefix for the arguments inline with the machine
emulator, it also allows for users to override this by
setting up a custom prefix if desired.

fixes #31 , fixes #33