### PR TITLE
feat: add support for creating cartesi lua config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@createdreamtech/carti-core": "^1.5.0",
+        "@createdreamtech/carti-core": "^1.6.0",
         "@ipld/dag-cbor": "^2.0.2",
         "@octokit/rest": "^18.0.12",
         "@types/commander": "^2.12.2",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@createdreamtech/carti-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.5.0.tgz",
-      "integrity": "sha512-2vAn1pABYWo9OT3t+d6M08q8pdCA86nD34rWI1kzBg5ppcKNXfoKQiTF0w015fpYO1FZRYOjlS7JriPorN8kEw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.0.tgz",
+      "integrity": "sha512-x03WzHY8ff/mn8fIyoLrD7ZF/xBUg85MWvP8otC5MedENgLWqV8FXMjWiaSHp9K6FioxCKdAScYPA9X6dloozQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",
@@ -15078,9 +15078,9 @@
       }
     },
     "@createdreamtech/carti-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.5.0.tgz",
-      "integrity": "sha512-2vAn1pABYWo9OT3t+d6M08q8pdCA86nD34rWI1kzBg5ppcKNXfoKQiTF0w015fpYO1FZRYOjlS7JriPorN8kEw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.0.tgz",
+      "integrity": "sha512-x03WzHY8ff/mn8fIyoLrD7ZF/xBUg85MWvP8otC5MedENgLWqV8FXMjWiaSHp9K6FioxCKdAScYPA9X6dloozQ==",
       "requires": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@createdreamtech/carti-core": "^1.5.0",
+    "@createdreamtech/carti-core": "^1.6.0",
     "@ipld/dag-cbor": "^2.0.2",
     "@octokit/rest": "^18.0.12",
     "@types/commander": "^2.12.2",

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -15,6 +15,8 @@ export interface Config {
     bundleListingManager: BundleManager
     repo: Repo
 }
+export const CARTI_DOCKER_PACKAGE_PATH ="/opt/carti/packages"
+
 const cartesiMachinePath = `${process.cwd()}/carti-machine-package.json`
 const bundlesPath = `${process.cwd()}/carti_bundles`
 const bundleListingFilename = ".bundles_index.json"


### PR DESCRIPTION
This feature adds support for outputing lua config
and refactors the build and install commands to work with this in
mind.

cartesi machine build no outputs just a machine configuration from
package.json

cartesi machine install installs a carti-machine-package.json
only this time it just produces the appropriate lua configuration
that can be customized to reference a basePath of your choosing
for running the script in the context be that local or in a
docker context

fixes #37, fixes #32