### PR TITLE
feat: add support for machine rm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@createdreamtech/carti-core": "^1.6.0",
+        "@createdreamtech/carti-core": "^1.6.1",
         "@ipld/dag-cbor": "^2.0.2",
         "@octokit/rest": "^18.0.12",
         "@types/commander": "^2.12.2",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@createdreamtech/carti-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.0.tgz",
-      "integrity": "sha512-x03WzHY8ff/mn8fIyoLrD7ZF/xBUg85MWvP8otC5MedENgLWqV8FXMjWiaSHp9K6FioxCKdAScYPA9X6dloozQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.1.tgz",
+      "integrity": "sha512-BdLhX8gKJX1oMNs4YuDysMsHmULf6Lj52FMVfOf+c+MxP6xk9Cjd0t7AYFRmnbKYpvCXtbkpsyu7U+Eu1UH0Ag==",
       "dependencies": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",
@@ -15078,9 +15078,9 @@
       }
     },
     "@createdreamtech/carti-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.0.tgz",
-      "integrity": "sha512-x03WzHY8ff/mn8fIyoLrD7ZF/xBUg85MWvP8otC5MedENgLWqV8FXMjWiaSHp9K6FioxCKdAScYPA9X6dloozQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@createdreamtech/carti-core/-/carti-core-1.6.1.tgz",
+      "integrity": "sha512-BdLhX8gKJX1oMNs4YuDysMsHmULf6Lj52FMVfOf+c+MxP6xk9Cjd0t7AYFRmnbKYpvCXtbkpsyu7U+Eu1UH0Ag==",
       "requires": {
         "@ipld/dag-cbor": "^2.0.2",
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
-    "@createdreamtech/carti-core": "^1.6.0",
+    "@createdreamtech/carti-core": "^1.6.1",
     "@ipld/dag-cbor": "^2.0.2",
     "@octokit/rest": "^18.0.12",
     "@types/commander": "^2.12.2",

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -110,16 +110,27 @@ const testMachineInitCommand=(dir:string, check:()=>true = ()=>true) =>{
 
 interface AddCmdOptions {
     length: string,
-    start: string
+    start: string,
+    label: string
 }
 
 const testMachineAddCmdArgs = (dir:string, bundleName: string, cmd: AddCmdOptions) => {
-    return `${cartiCmd(dir)} machine add flash ${bundleName} --start ${cmd.start} --length ${cmd.length}`
+    return `${cartiCmd(dir)} machine add flash ${bundleName} --start ${cmd.start} --length ${cmd.length} -m cool`
 }
 
 const testMachineAddCommand = (dir: string, bundleName: string, cmd: AddCmdOptions) => {
     return testUtil.createTestCommand(testMachineAddCmdArgs(dir, bundleName, cmd), () => true)
 }
+
+const testMachineRmCmdArgs = (dir:string, label:string) => {
+    return `${cartiCmd(dir)} machine rm flash ${label}`
+}
+
+const testMachineRmCommand = (dir: string, label:string) => {
+    return testUtil.createTestCommand(testMachineRmCmdArgs(dir, label), () => true)
+}
+
+
 
 const testMachineBuildArgs = (dir:string) => {
     return `${cartiCmd(dir)} machine build`
@@ -177,7 +188,9 @@ describe("integration tests for cli", () => {
             return true;
         })
         const machineAddCmd = testMachineAddCommand(remoteTestEnvironment.cwd, "dapp-test-data", 
-            { length: "0x100000", start: "0x8000000000000000" })
+            { length: "0x100000", start: "0x8000000000000000", label: "cool" })
+
+        const machineRmCmd = testMachineRmCommand(remoteTestEnvironment.cwd, "cool")
 
         const machineBuildCmd = testMachineBuildCommand(remoteTestEnvironment.cwd)
         const machineInstallCmd = testMachineInstallCommand(localTestEnvironment.cwd, `${remoteTestEnvironment.cwd}/carti-machine-package.json`)
@@ -192,7 +205,7 @@ describe("integration tests for cli", () => {
         expect(testUtil.testCommand(machineAddCmd, Object.assign({}, remoteTestEnvironment, { input: "\r\n" }))).toBe(true)
         expect(testUtil.testCommand(machineBuildCmd, remoteTestEnvironment)).toBe(true)
         expect(testUtil.testCommand(machineInstallCmd, localTestEnvironment)).toBe(true)
-
+        expect(testUtil.testCommand(machineRmCmd, Object.assign({}, remoteTestEnvironment, { input: "\r\n" }))).toBe(true)
 
     })
 


### PR DESCRIPTION
This features supports removal of drives from machine json with labels
as well as all bundle drives from the cli itself

fixes #40