### PR TITLE
feat: add global storage to carti

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -25,15 +25,18 @@ const renderBundle = (b: Bundle, uri: string): string => {
 
 async function handleList(config: Config, all:boolean): Promise<void> {
     let localList = await config.localConfigStorage.listing();
-    let globalList:Listing = {}; 
+    let globalList = await config.globalLocalConfigStorage.listing();
+    let uninstalledList:Listing = {}; 
     if(all)
-        globalList = await config.globalConfigStorage.listing()
+        uninstalledList = await config.globalConfigStorage.listing()
     const renderList = (list: Listing, uriType?: string): string[] => {
         let descs: string[] = []
         Object.keys(list).forEach((key: string) => {
-            descs = descs.concat(list[key].map((b: Bundle) => renderBundle(b, uriType || b.uri || 'global')))
+            descs = descs.concat(list[key].map((b: Bundle) => renderBundle(b, uriType || b.uri || 'uninstalled')))
         })
         return descs
     }
-    console.log(renderList(localList,'local').concat(renderList(globalList)).join('\r\n'))
+    console.log(renderList(localList,'local')
+        .concat(renderList(globalList, 'global'))
+        .concat(renderList(uninstalledList)).join('\r\n'))
 }

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -49,6 +49,8 @@ const renderBundle = (b: Bundle): string => {
     return shortDesc({ bundleType, name, version, id, uri: "local" })
 }
 
+// handlePublish has the restriction that you can only ever publish locally installed bundles publishing of global bundles are not allowed
+// it feels like too much flexibility if we do not initially have some artifical restrictions on behavior
 async function handlePublish(config: Config, name: string, storage: Storage, yes: boolean, uri?: string, nosave?: boolean): Promise<void> {
     const bundles: Bundle[] = await config.localConfigStorage.get(name)
     let bundle = bundles[0]
@@ -62,7 +64,7 @@ async function handlePublish(config: Config, name: string, storage: Storage, yes
     if (nosave) {
         return config.bundleListingManager.addBundle(bundleWithNewUri)
     }
-    const localPath = await config.bundleStorage.path(CID.parse(bundle.id))
+    const localPath = (await config.bundleStorage.path(CID.parse(bundle.id))).local
     const bundleWithPath = Object.assign({}, bundleWithNewUri, { path: localPath as string})
     const bun = await clib.bundle.bundle(bundleWithPath as bundle.BundleMeta, storage)
     bun.uri = uri

--- a/src/cli/commands/which.ts
+++ b/src/cli/commands/which.ts
@@ -4,6 +4,7 @@ import { Bundle } from "@createdreamtech/carti-core"
 import { Config } from "../../lib/config"
 import { CID } from "multiformats";
 import chalk from "chalk";
+import { CartiBundleStorage } from "../../lib/storage/carti_bundles";
 
 
 export const addWhichCommand = (config: Config): program.Command => {
@@ -23,9 +24,15 @@ const renderBundle = (b: Bundle, path:string): string => {
 }
 
 async function handleWhich(config: Config, name:string): Promise<void> {
-    const bundles = await config.localConfigStorage.get(name)
-    for (const bun of bundles){
-        const path =  await config.bundleStorage.path(CID.parse(bun.id))
-        console.log(renderBundle(bun,path))
+    let localBundles = await config.localConfigStorage.get(name)
+    let globalBundles = await config.globalLocalConfigStorage.get(name)
+    const showBundles = async (bundles: Bundle[], storage: CartiBundleStorage) => {
+        for (const bun of bundles) {
+            const path = await storage.path(CID.parse(bun.id))
+            console.log(renderBundle(bun, path))
+        }
     }
+    await showBundles(localBundles, config.bundleStorage.local)
+    await showBundles(globalBundles, config.bundleStorage.global)
+    return
 }

--- a/src/lib/storage/carti_bundles.ts
+++ b/src/lib/storage/carti_bundles.ts
@@ -13,3 +13,26 @@ export class CartiBundleStorage extends cartiLib.Storage {
         return this.diskProvider.path(cid)
     }
 }
+export interface BundlePath {
+    local?: string
+    global?: string
+}
+export class CartiBundleStorageSystem {
+    
+    global: CartiBundleStorage
+    local: CartiBundleStorage
+
+    constructor(global: CartiBundleStorage, local: CartiBundleStorage){
+        this.global = global
+        this.local = local 
+    }
+
+    async path(cid: CID, ): Promise<BundlePath> {
+        const local = await this.local.path(cid)
+        const global = await this.global.path(cid)
+        return {
+            local,
+            global
+        }
+    }
+}


### PR DESCRIPTION
Global storage is a feature that is a slight requirement for
supporting default packages. The storage implementation here
uses the same constructs as everywhere else just adds a little
extra searching in the cli layer vs core. This allows us to
swap out in the future storage paradigms and change the logic
in the cli as we see fit.

A usability global restriction was added to publish and bundle
while the code path exists to support publishing from global dir
and bundling from the global dir, this functionality is removed
from the cli.

Developing from a global dir is an easy way to footgun. So this
is rm'd. If we need it later for an explicit usecase we will add
it. You can work around it so it's not impossible.

This also introduces a build dir that can be opt'd out
in the future this may not be such an important feature.

However because much of cartesi is run in different context,
the ability to mount a unified path for the machine emulator is
invaluable. So carti_build/bundles is the location for all
bundles from an installed machine.json making it easy to
reference them in any context.