### PR TITLE
fix: ram default length is incorrect it does not behave like flash

### DIFF
--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -218,7 +218,11 @@ async function handleAdd(config: Config, name: string, options: clib.PackageEntr
     }
     let cfg = await getMachineConfig()
     // Note equivalent to lua config https://github.com/cartesi/machine-emulator/blob/master/src/cartesi-machine.lua#L638
-    options.length = options.length || `0x${BigInt(fs.statSync(bundle.fileName).size).toString(16)}` 
+    if(addType === "flashdrive")
+        options.length = options.length || `0x${BigInt(fs.statSync(bundle.fileName).size).toString(16)}` 
+    // Note ram default size is 64 << 20 https://github.com/cartesi/machine-emulator/blob/master/src/cartesi-machine.lua#L209
+    if(addType === "ram")
+        options.length = options.length || `0x${(BigInt(64)<< BigInt(20)).toString(16)}`
 
     // NOTE we respect commandline ideal of what the bundleType should be so if you install something in
     // ram you can install the same data as a flash drive

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -79,7 +79,7 @@ const defaultBoot: Boot = {
 }
 const defaultRam: Ram = {
     cid: "baenrwia5vqqvdu5chzjqq57tfo45z2txorpnmljeiuwemcibba43noqpvu",
-    length: "0x6a6000"
+    length: "0x4000000"
 }
 const defaultFlash: FlashDrive = [
     {


### PR DESCRIPTION
the default is 64 << 20. Otherwise it must be overriden via options