### PR TITLE
fix: correct listing file missing issue when installing machine

### DIFF
--- a/src/cli/commands/command_util.ts
+++ b/src/cli/commands/command_util.ts
@@ -9,7 +9,8 @@ export async function commandHandler<Args extends any[], Return>(
        const result = await operation(...parameters);
        return result
     } catch (e) {
-        console.error(`${chalk.bold(chalk.red("Error: "))}${chalk.red(e.message)}`)
+//        console.error(`${chalk.bold(chalk.red("Error: "))}${chalk.red(e.message)}`)
+console.error(e)
         exit(1)
     }
 }

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -217,6 +217,7 @@ async function handleInstall(config: Config, uri: string, nobuild:boolean, nobun
                     console.log(`adding repo: ${repo}`)
                 }
             } catch (e) {
+                debugger
                 console.log(`skipping, could not add ${repo} cause: ${e.message}`)
             }
         }

--- a/src/lib/storage/bundle_listing.ts
+++ b/src/lib/storage/bundle_listing.ts
@@ -44,6 +44,7 @@ export class BundleListing {
     }
 
     async has(path: string): Promise<boolean> {
+        if(this.exists() === false) return false
         const listing: Listing = await fs.readJSON(this.packageListingPath)
         return listing.hasOwnProperty(path)
     }


### PR DESCRIPTION
This is a fix to the bug introduced by having auto installation of
repos.
The patch was to ensure listing file exists prior to checking
entry existence