### PR TITLE
fix: refactor to use spawn vs spawnSync

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,5 @@ module.exports = {
   restoreMocks: true,
   rootDir: './src',
   testEnvironment: 'jsdom',
-  preset: 'ts-jest'
+  preset: 'ts-jest',
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "generate:types": "node utils/generate_types.js",
     "lint": "eslint -c .eslintrc.js --ext .ts",
     "test:c": "npm run lint && jest --coverage",
-    "test": "npm run build && npm run lint && jest"
+    "test": "npm run build && npm run lint && jest --testTimeout 250000",
+    "test:fast": "CARTI_TEST_LOCAL=true jest --testTimeout 250000"
   },
   "bin": {
     "carti": "build/src/cli/index.js"

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,7 +1,7 @@
 import * as testUtil from "../test/test_util"
 import fs from "fs-extra"
 import rimraf from "rimraf"
-import {promisify} from "util"
+import { promisify } from "util"
 import { spawnSync, SpawnSyncReturns } from "child_process"
 import os from "os"
 
@@ -15,17 +15,22 @@ const LOCAL_TEST_PROJECT_DIR = `${LOCAL_BASE_TEST_DIR}/local-project`
 const REMOTE_BASE_TEST_DIR = fs.mkdtempSync(`${os.tmpdir()}/test-carti`)
 const REMOTE_TEST_HOME = REMOTE_BASE_TEST_DIR
 const REMOTE_TEST_PROJECT_DIR = `${REMOTE_BASE_TEST_DIR}/remote-project`
-
-const createTestEnvironment = (projectDir: string, testHome: string): testUtil.TestEnv => {
+// Takes project directory to build, test home directory, and then if local specified it sets the 
+// node_path to be the cwd for testing purposes
+const createTestEnvironment = (projectDir: string, testHome: string, local: boolean): testUtil.TestEnv => {
     fs.ensureDirSync(projectDir)
+    let env: any = { HOME: testHome, PATH: process.env.PATH }
+    if (local)
+        env["NODE_PATH"] = `${process.cwd()}/node_modules`
     return {
         cwd: projectDir,
-        env: { HOME: testHome, PATH: process.env.PATH }
+        env
     }
 }
+const CARTI_TEST_LOCAL = process.env["CARTI_TEST_LOCAL"] ? true : false;
+const localTestEnvironment = createTestEnvironment(LOCAL_TEST_PROJECT_DIR, LOCAL_TEST_HOME, CARTI_TEST_LOCAL)
+const remoteTestEnvironment = createTestEnvironment(REMOTE_TEST_PROJECT_DIR, REMOTE_TEST_HOME, CARTI_TEST_LOCAL)
 
-const localTestEnvironment = createTestEnvironment(LOCAL_TEST_PROJECT_DIR, LOCAL_TEST_HOME)
-const remoteTestEnvironment = createTestEnvironment(REMOTE_TEST_PROJECT_DIR, REMOTE_TEST_HOME)
 const contains = (phrase: string) => {
     return (res: SpawnSyncReturns<Buffer>): boolean => {
         if (res.error || !res.stdout)
@@ -34,81 +39,82 @@ const contains = (phrase: string) => {
         return output.match(phrase) !== null
     }
 }
-
-const helpCommand = testUtil.createTestCommand("npx carti help", contains("help"))
-const setup = (env: testUtil.TestEnv) => {
-    // setup environment to install itself in a clean dir
-    spawnSync("npm", ["pack"])
-    const cartiNodePackage = `createdreamtech-carti-${version}.tgz`
-    fs.copyFileSync(`${process.cwd()}/${cartiNodePackage}`, `${env.cwd}/${cartiNodePackage}`)
-    fs.copyFileSync(`${__dirname}/../fixtures/dapp-test-data.ext2`, `${env.cwd}/dapp-test-data.ext2`)
-    //npm is special and messes with the env
-    spawnSync("npm", ["init", "-y"], { cwd: env.cwd })
-
-    const res = spawnSync("npm", ["install", `${env.cwd}/${cartiNodePackage}`], { cwd: env.cwd })
-    if (res.error)
-        console.error(res.error)
-
-    const result = testUtil.testCommand(helpCommand, env)
-    if (result === false) {
-        throw new Error("could not setup test")
+const containsAsync = (phrase: string) => {
+    return (res: string): boolean => {
+        return res.match(phrase) !== null
     }
 }
-//fs.copyFileSync("../../../fixtures/ram.ext2", localTestEnvironment.cwd
+
 const cartiCmd = (pth: string) => `${pth}/node_modules/.bin/carti`
-const { cwd } = localTestEnvironment;
-// const cartiCmd="carti"
-const testBundleCmdArgs = (dir:string)=>{
+const setup = async (env: testUtil.TestEnv, local: boolean) => {
+    // setup environment to install itself in a clean dir
+    // set a static package directory to skip npm pack
+    if (!local) {
+        spawnSync("npm", ["pack"])
+        const cartiNodePackage = `createdreamtech-carti-${version}.tgz`
+        fs.copyFileSync(`${process.cwd()}/${cartiNodePackage}`, `${env.cwd}/${cartiNodePackage}`)
+        spawnSync("npm", ["init", "-y"], { cwd: env.cwd })
+        const res = spawnSync("npm", ["install", `${env.cwd}/${cartiNodePackage}`], { cwd: env.cwd })
+        if (res.error)
+            console.error(res.error)
+    }
+    fs.copyFileSync(`${__dirname}/../fixtures/dapp-test-data.ext2`, `${env.cwd}/dapp-test-data.ext2`)
+    const helpCommand = testUtil.createTestCommand(`${cartiCmd(env.cwd)} --help`, containsAsync("help"))
+    await testUtil.testCommand(helpCommand, env, local)
+}
+
+
+const testBundleCmdArgs = (dir: string) => {
     return `${cartiCmd(dir)} bundle -t flashdrive -n dapp-test-data -v 1.0.0 -d hello_world_flash_drive dapp-test-data.ext2`
 }
 
-const testBundleCommand =(dir:string)=>{ 
-    return testUtil.createTestCommand(testBundleCmdArgs(dir), (res: SpawnSyncReturns<Buffer>) => { 
-       // console.log(res.stdout.toString())
-       // console.error(res.stderr.toString())
-       // TODO refactor this to better support the async nature of spawn
+const testBundleCommand = (dir: string) => {
+    return testUtil.createTestCommand(testBundleCmdArgs(dir), (res: SpawnSyncReturns<Buffer>) => {
+        // console.log(res.stdout.toString())
+        // console.error(res.stderr.toString())
+        // TODO refactor this to better support the async nature of spawn
         return true // contains("bundled: dapp-test-data")(res) 
     })
 }
 
-const testBundleInstallArgs=(dir:string , bundleName: string) => {
+const testBundleInstallArgs = (dir: string, bundleName: string) => {
     return `${cartiCmd(dir)} install ${bundleName}`
 }
 
-const testBundleInstallCommand=(dir: string, bundleName: string)=> {
-    return testUtil.createTestCommand(testBundleInstallArgs(dir, bundleName), () => true) 
+const testBundleInstallCommand = (dir: string, bundleName: string) => {
+    return testUtil.createTestCommand(testBundleInstallArgs(dir, bundleName), () => true)
 }
 
-const testGetArgs=(dir:string, bundleName: string)=> {
+const testGetArgs = (dir: string, bundleName: string) => {
     return `${cartiCmd(dir)} get -y ${bundleName}`
 }
 
-const testGetCommmand=(dir:string ,bundleName: string)=> {
-    return testUtil.createTestCommand(testGetArgs(dir, bundleName), () => true) 
+const testGetCommmand = (dir: string, bundleName: string) => {
+    return testUtil.createTestCommand(testGetArgs(dir, bundleName), () => true)
 }
 
-const diskLocation = (dir:string) =>
+const diskLocation = (dir: string) =>
     `${dir}/carti_bundles/baenrwic6ybfsdmdtm52fhgbeip6ndoi3e62bonaadmotji4x6vvdpedt3m/dapp-test-data.ext2`
 const testPublishCmdArgs = (dir: string, uri: string) => {
     return `${cartiCmd(dir)} publish uri dapp-test-data ${uri}`
 }
-const testPublishCommand = (dir:string, uri:string) => {
-    return testUtil.createTestCommand(testPublishCmdArgs(dir, uri), ()=>true);
+const testPublishCommand = (dir: string, uri: string) => {
+    return testUtil.createTestCommand(testPublishCmdArgs(dir, uri), () => true);
 }
 
-const testAddRepoCmdArgs = (dir:string, uri:string)=> {
+const testAddRepoCmdArgs = (dir: string, uri: string) => {
     return `${cartiCmd(dir)} repo add ${uri}`
 }
 
-const testAddRepoCommand = (dir:string, uri: string) => {
+const testAddRepoCommand = (dir: string, uri: string) => {
     return testUtil.createTestCommand(testAddRepoCmdArgs(dir, uri), () => true)
 }
 
-const testMachineInitCmdArgs = (dir:string) =>{
+const testMachineInitCmdArgs = (dir: string) => {
     return `${cartiCmd(dir)} machine init`
 }
 
-const testMachineInitCommand=(dir:string, check:()=>true = ()=>true) =>{
+const testMachineInitCommand = (dir: string, check: () => true = () => true) => {
     return testUtil.createTestCommand(testMachineInitCmdArgs(dir), check)
 }
 
@@ -118,7 +124,7 @@ interface AddCmdOptions {
     label: string
 }
 
-const testMachineAddCmdArgs = (dir:string, bundleName: string, cmd: AddCmdOptions) => {
+const testMachineAddCmdArgs = (dir: string, bundleName: string, cmd: AddCmdOptions) => {
     return `${cartiCmd(dir)} machine add flash ${bundleName} --start ${cmd.start} --length ${cmd.length} -m cool`
 }
 
@@ -126,17 +132,15 @@ const testMachineAddCommand = (dir: string, bundleName: string, cmd: AddCmdOptio
     return testUtil.createTestCommand(testMachineAddCmdArgs(dir, bundleName, cmd), () => true)
 }
 
-const testMachineRmCmdArgs = (dir:string, label:string) => {
+const testMachineRmCmdArgs = (dir: string, label: string) => {
     return `${cartiCmd(dir)} machine rm flash ${label}`
 }
 
-const testMachineRmCommand = (dir: string, label:string) => {
+const testMachineRmCommand = (dir: string, label: string) => {
     return testUtil.createTestCommand(testMachineRmCmdArgs(dir, label), () => true)
 }
 
-
-
-const testMachineBuildArgs = (dir:string) => {
+const testMachineBuildArgs = (dir: string) => {
     return `${cartiCmd(dir)} machine build`
 }
 
@@ -144,19 +148,20 @@ const testMachineBuildCommand = (dir: string) => {
     return testUtil.createTestCommand(testMachineBuildArgs(dir), () => true)
 }
 
-const testMachineInstallArgs = (dir:string, uri: string) => {
+const testMachineInstallArgs = (dir: string, uri: string) => {
     return `${cartiCmd(dir)} machine install ${uri}`
 }
 
-const testMachineInstallCommand = (dir: string, uri:string) => {
+const testMachineInstallCommand = (dir: string, uri: string) => {
     return testUtil.createTestCommand(testMachineInstallArgs(dir, uri), () => true)
 }
 
 describe("integration tests for cli", () => {
-    afterAll(async ()=>{
+    afterAll(async () => {
         await rmAll(LOCAL_BASE_TEST_DIR)
         await rmAll(REMOTE_BASE_TEST_DIR)
     })
+
     /*
         The test pattern for this is 
         local builds bundle
@@ -167,22 +172,22 @@ describe("integration tests for cli", () => {
         remote builds machine
         local installs remote's machine creating a stored_machine
     */
-    it("should bundle a flash drive, publish it, install it, create a machine, and install the machine", () => {
-           setup(localTestEnvironment)
-           setup(remoteTestEnvironment)
+    it("should bundle a flash drive, publish it, install it, create a machine, and install the machine", async () => {
+        await setup(localTestEnvironment, CARTI_TEST_LOCAL)
+        await setup(remoteTestEnvironment, CARTI_TEST_LOCAL)
 
         const localBundleCmd = testBundleCommand(localTestEnvironment.cwd)
         const publishBundleCmd = testPublishCommand(localTestEnvironment.cwd,
             diskLocation(localTestEnvironment.cwd))
         const addRepoCmd = testAddRepoCommand(remoteTestEnvironment.cwd,
             localTestEnvironment.cwd)
-        const installBundleCmd = testBundleInstallCommand(remoteTestEnvironment.cwd,"dapp-test-data")
+        const installBundleCmd = testBundleInstallCommand(remoteTestEnvironment.cwd, "dapp-test-data")
         const getCmd = testGetCommmand(remoteTestEnvironment.cwd, "dapp-test-data")
-        const machineInitCmd = testMachineInitCommand(remoteTestEnvironment.cwd, ()=> {
+        const machineInitCmd = testMachineInitCommand(remoteTestEnvironment.cwd, () => {
 
-        // NOTE by default the init fills out a config with default settings so you must edit the file specifically
-        // for your flash drive, there is a concurrency issue that prevents this from happening.
-        // not explicitly after  the command has finished. Hence this inline code here
+            // NOTE by default the init fills out a config with default settings so you must edit the file specifically
+            // for your flash drive, there is a concurrency issue that prevents this from happening.
+            // not explicitly after  the command has finished. Hence this inline code here
             const machineFile = fs.readFileSync(`${remoteTestEnvironment.cwd}/carti-machine-package.json`)
             const machineJSON = JSON.parse(machineFile.toString())
             machineJSON.machineConfig.flash_drive = machineJSON.machineConfig.flash_drive
@@ -191,27 +196,29 @@ describe("integration tests for cli", () => {
                 JSON.stringify(machineJSON, null, 2))
             return true;
         })
-        const machineAddCmd = testMachineAddCommand(remoteTestEnvironment.cwd, "dapp-test-data", 
+        const machineAddCmd = testMachineAddCommand(remoteTestEnvironment.cwd, "dapp-test-data",
             { length: "0x100000", start: "0x8000000000000000", label: "cool" })
 
         const machineRmCmd = testMachineRmCommand(remoteTestEnvironment.cwd, "cool")
 
         const machineBuildCmd = testMachineBuildCommand(remoteTestEnvironment.cwd)
         const machineInstallCmd = testMachineInstallCommand(localTestEnvironment.cwd, `${remoteTestEnvironment.cwd}/carti-machine-package.json`)
-
-        expect(testUtil.testCommand(localBundleCmd, localTestEnvironment)).toBe(true)
+        expect(await testUtil.testCommand(localBundleCmd, localTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
         //otherwise throws exception
-        expect(testUtil.testCommand(publishBundleCmd, Object.assign({},localTestEnvironment,{input: "\r\n"}))).toBe(true)
-        expect(testUtil.testCommand(addRepoCmd, remoteTestEnvironment)).toBe(true)
-        expect(testUtil.testCommand(getCmd, remoteTestEnvironment)).toBe(true)
-        expect(testUtil.testCommand(installBundleCmd, Object.assign({},remoteTestEnvironment,{input:"\r\n"}))).toBe(true)
-        expect(testUtil.testCommand(machineInitCmd, remoteTestEnvironment)).toBe(true)
-        expect(testUtil.testCommand(machineAddCmd, Object.assign({}, remoteTestEnvironment, { input: "\r\n" }))).toBe(true)
-        expect(testUtil.testCommand(machineBuildCmd, remoteTestEnvironment)).toBe(true)
-        expect(testUtil.testCommand(machineInstallCmd, localTestEnvironment)).toBe(true)
-        expect(testUtil.testCommand(machineRmCmd, Object.assign({}, remoteTestEnvironment, { input: "\r\n" }))).toBe(true)
-
+        
+        expect(await testUtil.testCommand(publishBundleCmd, Object.assign({}, localTestEnvironment, { input: "\r\n" }), CARTI_TEST_LOCAL)).toBe(true)
+       
+        expect(await testUtil.testCommand(addRepoCmd, remoteTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(getCmd, remoteTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(installBundleCmd, Object.assign({},
+            remoteTestEnvironment, { input: "\r\n" }), CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(machineInitCmd, remoteTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(machineAddCmd,
+            Object.assign({}, remoteTestEnvironment, { input: "\r\n" }), CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(machineBuildCmd, remoteTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(machineInstallCmd, localTestEnvironment, CARTI_TEST_LOCAL)).toBe(true)
+        expect(await testUtil.testCommand(machineRmCmd,
+            Object.assign({}, remoteTestEnvironment, { input: "\r\n" }), CARTI_TEST_LOCAL)).toBe(true)
     })
-
 
 })

--- a/src/test/test_util.ts
+++ b/src/test/test_util.ts
@@ -1,50 +1,68 @@
-import { spawnSync } from "child_process"
-import { stderr, stdin } from "process";
-import { ReadStream } from "tty";
+import { spawnSync, spawn } from "child_process"
+import { Readable } from "stream";
 
 export interface TestCommand {
     command:Array<string>
     check: (...x: any)=> boolean
 }
+
 export function createTestCommand(cmd: string, check: (...x: any) => boolean): TestCommand{
     const command = cmd.split(" ")
     return { command, check }    
 }
+
 export interface TestEnv {
     cwd: string 
     env: { [key: string]: any }
     input?: string | Buffer | DataView 
 }
 
-export function testCommand(cmd: TestCommand, env:TestEnv){
-    const [command, ...args] = cmd.command;
-    const res = spawnSync(command, args, env)
-    
-    if(res.error){
-        console.error(stderr.toString())
-        throw  res.error 
+export async function testCommand(cmd: TestCommand, env: TestEnv, local: boolean) {
+
+    let [command, ...args] = cmd.command;
+    if(local){
+        command = "node"
+        args = [`${process.cwd()}/build/src/cli/index.js`].concat(args)
     }
-    return cmd.check(res)
+    const { check } = cmd;
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args,  {...env, stdio: 'pipe'})
+        const stderrOutput = []
+        const stdOutput = []
+
+        const outputHandler = async (std: Readable, check: (...x: any) => boolean) => {
+            const output: Uint8Array[] = []
+            return new Promise((resolve, reject) => {
+                let result = false;
+                std.on("data", (datum) => {
+                    output.push(datum)
+                })
+                std.on("end", () => {
+                    result = check(Buffer.concat(output).toString('utf8'))
+                })
+                std.on("close", ()=>{
+                    resolve(result)
+                })
+            })
+        }
+        const prom = outputHandler(child.stdout, check);
+        child.on("close", async (code: number, signal: NodeJS.Signals) => {
+            if (code === 1) {
+                reject(new Error(`${JSON.stringify(cmd)} failure with ${JSON.stringify(env)}`))
+            }
+        })
+        child.on("exit", async ()=>{
+            resolve (await prom)
+        })
+
+        if(env.input) {
+            child.stdin.write(env.input);
+            child.stdin.end();
+        }
+    })
 }
 
 export function shellCommand(cmd:string, env:TestEnv){
     const [command, ...args] = cmd.split(" ");
     return spawnSync(command, args, env)
 }
-
-// createTestCommand("machine init")
-/*
-
- command = createTestCommand("machine blargh foobar", (output) =>{
-
- })
- it("should add blarghy to blop", ()=>{
-    [ addPackage,
-      removePackage,
-
- })
- testCommand(command) 
- itestCommand()
-
-
-*/


### PR DESCRIPTION
This fix refactors away from using spawnSync, which
problematically exited early on output making integration
test potentially unreliable.

This change allows for proper output testing as well as an
extended timeout for npm, as this can take substantial
time depending on the machine for integration test.